### PR TITLE
Make blog post titles clickable links

### DIFF
--- a/src/LinkBlog.Web/Components/Posts/BlogPost.razor
+++ b/src/LinkBlog.Web/Components/Posts/BlogPost.razor
@@ -7,7 +7,7 @@
     <article class="post">
         <header>
             <div class="post-title">
-                <h2>@DisplayPost.Title</h2>
+                <h2><a href="@DisplayPost.UrlPath">@DisplayPost.Title</a></h2>
                 <AuthorizeView Policy="Admin">
                     <a class="edit-btn" href="/admin/@DisplayPost.Id">
                         <svg xmlns="http://www.w3.org/2000/svg"

--- a/src/LinkBlog.Web/Components/Posts/BlogPost.razor.css
+++ b/src/LinkBlog.Web/Components/Posts/BlogPost.razor.css
@@ -35,6 +35,16 @@
     justify-content: space-between; /* space-between pushes the title to the left and the button to the right. */
 }
 
+/* Title link styling */
+.post-title h2 a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.post-title h2 a:hover {
+    text-decoration: underline;
+}
+
 /* Edit button style */
 button.edit-btn {
     background: none;


### PR DESCRIPTION
- Wrapped blog post titles in anchor tags linking to the post URL
- Added CSS styling to remove default link underline
- Added hover effect to indicate titles are clickable