### PR TITLE
Make Atom feed metadata configurable through FeedOptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,18 +10,12 @@ aspire run
 
 # Run unit tests only (excludes integration tests that require Docker)
 dotnet test --filter "Category!=IntegrationTest"
-# Or using Just:
-just test-unit
 
 # Run integration tests only (requires Docker)
 dotnet test --filter "Category=IntegrationTest"
-# Or using Just:
-just test-integration
 
 # Run all tests (unit + integration, requires Docker for integration tests)
 dotnet test
-# Or using Just:
-just test-all
 
 # Check for outdated packages
 dotnet outdated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,14 +8,27 @@ dotnet build
 # Run the application
 aspire run
 
-# Run tests
-dotnet test
+# Run unit tests only (excludes integration tests that require Docker)
+dotnet test --filter "Category!=IntegrationTest"
+# Or using Just:
+just test-unit
 
-# Check for oudated packages
+# Run integration tests only (requires Docker)
+dotnet test --filter "Category=IntegrationTest"
+# Or using Just:
+just test-integration
+
+# Run all tests (unit + integration, requires Docker for integration tests)
+dotnet test
+# Or using Just:
+just test-all
+
+# Check for outdated packages
 dotnet outdated
 
 # Update outdated packages
 dotnet outdated -u
+```
 
 ## Code Style Guidelines
 - **Naming**: PascalCase for classes, methods, public properties; camelCase for parameters and private fields

--- a/src/LinkBlog.Feed/AtomFeed.cs
+++ b/src/LinkBlog.Feed/AtomFeed.cs
@@ -12,7 +12,6 @@ public interface ISyndicationFeed
 
 public class AtomFeed : ISyndicationFeed
 {
-    private readonly string blogUrl = "https://davidjarman.net";
     private readonly FeedOptions _options;
 
     public AtomFeed(IOptions<FeedOptions> options)
@@ -24,13 +23,12 @@ public class AtomFeed : ISyndicationFeed
     {
         StringBuilder sb = new();
 
-        // TODO: Remove hardcoded elements and pass them in to class from LinkBlog.Web
         sb.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
         sb.Append("<feed xmlns=\"http://www.w3.org/2005/Atom\">");
-        sb.Append("<title>David Jarman's Blog</title>");
-        sb.Append(string.Create(CultureInfo.InvariantCulture, $"<link href=\"{blogUrl}/\" rel=\"alternate\"/>"));
-        sb.Append(string.Create(CultureInfo.InvariantCulture, $"<id>{blogUrl}/</id>"));
-        sb.Append("<author><name>David Jarman</name></author>");
+        sb.Append(string.Create(CultureInfo.InvariantCulture, $"<title>{_options.BlogTitle}</title>"));
+        sb.Append(string.Create(CultureInfo.InvariantCulture, $"<link href=\"{_options.BlogUrl}/\" rel=\"alternate\"/>"));
+        sb.Append(string.Create(CultureInfo.InvariantCulture, $"<id>{_options.BlogUrl}/</id>"));
+        sb.Append(string.Create(CultureInfo.InvariantCulture, $"<author><name>{_options.AuthorName}</name></author>"));
 
         var latestPost = posts.First();
         sb.Append(CultureInfo.InvariantCulture, $"<updated>{latestPost.CreatedDate.ToString("o")}</updated>");
@@ -48,7 +46,7 @@ public class AtomFeed : ISyndicationFeed
     private StringBuilder CreateEntryForPost(Post post)
     {
         StringBuilder sb = new();
-        string postUrl = $"{blogUrl}{post.UrlPath}";
+        string postUrl = $"{_options.BlogUrl}{post.UrlPath}";
 
         sb.Append("<entry>");
 

--- a/src/LinkBlog.Feed/FeedOptions.cs
+++ b/src/LinkBlog.Feed/FeedOptions.cs
@@ -3,4 +3,7 @@ namespace LinkBlog.Feed;
 public class FeedOptions
 {
     public int MaxPostCount { get; set; } = 20;
+    public string BlogUrl { get; set; } = string.Empty;
+    public string BlogTitle { get; set; } = string.Empty;
+    public string AuthorName { get; set; } = string.Empty;
 }

--- a/src/LinkBlog.Web/appsettings.json
+++ b/src/LinkBlog.Web/appsettings.json
@@ -7,7 +7,10 @@
   },
   "AllowedHosts": "*",
   "Feed": {
-    "MaxPostCount": 20
+    "MaxPostCount": 20,
+    "BlogUrl": "https://davidjarman.net",
+    "BlogTitle": "David Jarman's Blog",
+    "AuthorName": "David Jarman"
   },
   "PostStoreOptions": {
     "EnableInMemoryCache": true,


### PR DESCRIPTION
Resolves TODO in AtomFeed.cs by removing hardcoded blog URL, title,
and author name. These values are now configurable through the
FeedOptions class and can be set in appsettings.json.

Changes:
- Added BlogUrl, BlogTitle, and AuthorName properties to FeedOptions
- Updated AtomFeed.cs to use configuration instead of hardcoded values
- Added default values to appsettings.json for backward compatibility