### PR TITLE
Add Playwright E2E tests for home page and post creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       run: dotnet build LinkBlog.slnx --no-restore
 
     - name: Ensure browsers are installed
-      run: pwsh bin/Debug/net10.0/playwright.ps1 install --with-deps
+      run: pwsh test/LinkBlog.Playwright.Tests/bin/Debug/net10.0/playwright.ps1 install --with-deps
 
     - name: Test
       run: dotnet test LinkBlog.slnx --no-build --verbosity normal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,18 +16,15 @@ jobs:
     - uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '10.0.x'
-    - uses: actions/setup-node@v5
-      with:
-        node-version: lts/*
-
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
 
     - name: Restore dependencies
       run: dotnet restore LinkBlog.slnx
 
     - name: Build
       run: dotnet build LinkBlog.slnx --no-restore
+
+    - name: Ensure browsers are installed
+      run: pwsh bin/Debug/net10.0/playwright.ps1 install --with-deps
 
     - name: Test
       run: dotnet test LinkBlog.slnx --no-build --verbosity normal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+    - uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '10.0.x'
+    - uses: actions/setup-node@v5
+      with:
+        node-version: lts/*
+
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
 
     - name: Restore dependencies
       run: dotnet restore LinkBlog.slnx

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,9 +23,11 @@
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
 
     <!-- Test packages -->
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.2.2" />
     <PackageVersion Include="bunit" Version="2.7.2" />
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.51.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/LinkBlog.slnx
+++ b/LinkBlog.slnx
@@ -8,5 +8,6 @@
     <Project Path="src/LinkBlog.ServiceDefaults/LinkBlog.ServiceDefaults.csproj" />
     <Project Path="src/LinkBlog.Web/LinkBlog.Web.csproj" />
     <Project Path="test/LinkBlog.Web.Tests/LinkBlog.Web.Tests.csproj" />
+    <Project Path="test/LinkBlog.Playwright.Tests/LinkBlog.Playwright.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/LinkBlog.Web/Components/Pages/Admin/AdminHome.razor
+++ b/src/LinkBlog.Web/Components/Pages/Admin/AdminHome.razor
@@ -4,11 +4,13 @@
 @using LinkBlog.Abstractions
 @using LinkBlog.Data
 @using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.OutputCaching
 @using System.ComponentModel.DataAnnotations
 @attribute [Authorize(Policy = "Admin")]
 
 @inject IPostStore PostStore
 @inject ILogger<AdminHome> Logger
+@inject IOutputCacheStore OutputCacheStore
 
 <HeadContent>
     <link rel="stylesheet" type="text/css" href="/css/easymde.min.css">
@@ -211,6 +213,7 @@
             {
                 if (await PostStore.UpdatePostAsync(Id, post, tagNames))
                 {
+                    await OutputCacheStore.EvictByTagAsync("posts", CancellationToken.None);
                     OnSuccess("Post updated successfully");
                 }
                 else
@@ -236,6 +239,7 @@
 
             if (success)
             {
+                await OutputCacheStore.EvictByTagAsync("posts", CancellationToken.None);
                 OnSuccess("Post created successfully");
             }
             else

--- a/src/LinkBlog.Web/Components/Pages/Home.razor
+++ b/src/LinkBlog.Web/Components/Pages/Home.razor
@@ -4,7 +4,7 @@
 @using LinkBlog.Data
 @using LinkBlog.Web.Components.Posts
 @using Microsoft.Extensions.Options
-@attribute [OutputCache(Duration = 60, VaryByRouteValueNames = new[] { "PageNumber" })]
+@attribute [OutputCache(Duration = 60, VaryByRouteValueNames = new[] { "PageNumber" }, Tags = new[] { "posts" })]
 
 @inject IPostStore PostStore
 @inject IOptions<BlogOptions> BlogOptions

--- a/src/LinkBlog.Web/Controllers/AdminController.cs
+++ b/src/LinkBlog.Web/Controllers/AdminController.cs
@@ -1,6 +1,7 @@
 using LinkBlog.Data;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 
 namespace LinkBlog.Web.Controllers;
 
@@ -9,10 +10,12 @@ namespace LinkBlog.Web.Controllers;
 public class AdminController : Controller
 {
     private readonly IPostStore postStore;
+    private readonly IOutputCacheStore outputCacheStore;
 
-    public AdminController(IPostStore postStore)
+    public AdminController(IPostStore postStore, IOutputCacheStore outputCacheStore)
     {
         this.postStore = postStore;
+        this.outputCacheStore = outputCacheStore;
     }
 
     [HttpPost("{id}/archive")]
@@ -24,6 +27,7 @@ public class AdminController : Controller
             return NotFound();
         }
 
+        await outputCacheStore.EvictByTagAsync("posts", ct);
         return Redirect("/admin?message=Post%20archived%20successfully");
     }
 }

--- a/test/LinkBlog.Playwright.Tests/AdminPageTests.cs
+++ b/test/LinkBlog.Playwright.Tests/AdminPageTests.cs
@@ -1,0 +1,82 @@
+using Aspire.Hosting;
+using Aspire.Hosting.Testing;
+using Microsoft.Playwright;
+
+namespace LinkBlog.Playwright.Tests;
+
+public class AdminPageTests : IAsyncLifetime
+{
+    private DistributedApplication? _app;
+    private IPlaywright? _playwright;
+    private IBrowser? _browser;
+    private string _baseUrl = "";
+
+    public async Task InitializeAsync()
+    {
+        // Bypass GitHub OAuth for admin pages in test environment
+        Environment.SetEnvironmentVariable("DisableAdminAuth", "true");
+
+        var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.LinkBlog_AppHost>();
+        _app = await appHost.BuildAsync();
+        await _app.StartAsync();
+
+        var httpClient = _app.CreateHttpClient("webfrontend");
+        _baseUrl = httpClient.BaseAddress!.ToString().TrimEnd('/');
+
+        _playwright = await Microsoft.Playwright.Playwright.CreateAsync();
+        _browser = await _playwright.Chromium.LaunchAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        Environment.SetEnvironmentVariable("DisableAdminAuth", null);
+        if (_browser is not null) await _browser.DisposeAsync();
+        _playwright?.Dispose();
+        if (_app is not null) await _app.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task AdminPage_CreatePost_AppearsOnHomePage()
+    {
+        // Use a unique short title per test run to avoid conflicts with existing data
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var postTitle = $"Playwright Test Post {timestamp}";
+        var shortTitle = $"playwright-test-{timestamp}";
+        const string postContent = "This is a test post created by Playwright.";
+        const string postTags = "test";
+
+        var page = await _browser!.NewPageAsync();
+
+        // Navigate to the admin page
+        await page.GotoAsync($"{_baseUrl}/admin");
+        await Assertions.Expect(page).ToHaveTitleAsync("Admin");
+
+        // Fill in the post form
+        await page.Locator("#PostTitle").FillAsync(postTitle);
+        await page.Locator("#ShortTitle").FillAsync(shortTitle);
+
+        // Set the EasyMDE/CodeMirror editor content via the underlying CodeMirror API,
+        // then dispatch a change event so EasyMDE syncs the value to the hidden textarea
+        await page.Locator(".CodeMirror").WaitForAsync();
+        await page.EvaluateAsync(@"(content) => {
+            var cmElement = document.querySelector('.CodeMirror');
+            var cm = cmElement.CodeMirror;
+            cm.setValue(content);
+            cm.getDoc().markClean();
+        }", postContent);
+
+        await page.Locator("#PostTags").FillAsync(postTags);
+
+        // Submit the form
+        await page.Locator("button.btn-primary[type=submit]").ClickAsync();
+
+        // Wait for the success confirmation
+        await Assertions.Expect(page.Locator(".alert-success")).ToBeVisibleAsync();
+
+        // Navigate to the home page and verify the new post appears
+        await page.GotoAsync(_baseUrl);
+        await Assertions.Expect(
+            page.GetByRole(AriaRole.Heading, new() { Name = postTitle })
+        ).ToBeVisibleAsync();
+    }
+}

--- a/test/LinkBlog.Playwright.Tests/AdminPageTests.cs
+++ b/test/LinkBlog.Playwright.Tests/AdminPageTests.cs
@@ -1,4 +1,5 @@
 using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Testing;
 using Microsoft.Playwright;
 
@@ -20,8 +21,10 @@ public class AdminPageTests : IAsyncLifetime
         _app = await appHost.BuildAsync();
         await _app.StartAsync();
 
-        var httpClient = _app.CreateHttpClient("webfrontend");
-        _baseUrl = httpClient.BaseAddress!.ToString().TrimEnd('/');
+        var webResource = appHost.Resources.First(r=>r.Name == "webfrontend");
+        var endpoint = webResource.Annotations.OfType<EndpointAnnotation>().First(x => x.Name == "http");
+
+        _baseUrl = endpoint.AllocatedEndpoint!.UriString;
 
         _playwright = await Microsoft.Playwright.Playwright.CreateAsync();
         _browser = await _playwright.Chromium.LaunchAsync();

--- a/test/LinkBlog.Playwright.Tests/AdminPageTests.cs
+++ b/test/LinkBlog.Playwright.Tests/AdminPageTests.cs
@@ -48,7 +48,11 @@ public class AdminPageTests : IAsyncLifetime
         const string postContent = "This is a test post created by Playwright.";
         const string postTags = "test";
 
-        var page = await _browser!.NewPageAsync();
+        BrowserNewPageOptions options = new()
+        {
+            IgnoreHTTPSErrors = true
+        };
+        var page = await _browser!.NewPageAsync(options);
 
         // Navigate to the admin page
         await page.GotoAsync($"{_baseUrl}/admin");

--- a/test/LinkBlog.Playwright.Tests/AdminPageTests.cs
+++ b/test/LinkBlog.Playwright.Tests/AdminPageTests.cs
@@ -21,7 +21,7 @@ public class AdminPageTests : IAsyncLifetime
         _app = await appHost.BuildAsync();
         await _app.StartAsync();
 
-        var webResource = appHost.Resources.First(r=>r.Name == "webfrontend");
+        var webResource = appHost.Resources.First(r => r.Name == "webfrontend");
         var endpoint = webResource.Annotations.OfType<EndpointAnnotation>().First(x => x.Name == "http");
 
         _baseUrl = endpoint.AllocatedEndpoint!.UriString;

--- a/test/LinkBlog.Playwright.Tests/HomePageTests.cs
+++ b/test/LinkBlog.Playwright.Tests/HomePageTests.cs
@@ -1,0 +1,64 @@
+using Aspire.Hosting;
+using Aspire.Hosting.Testing;
+using Microsoft.Playwright;
+
+namespace LinkBlog.Playwright.Tests;
+
+public class HomePageTests : IAsyncLifetime
+{
+    private DistributedApplication? _app;
+    private IPlaywright? _playwright;
+    private IBrowser? _browser;
+    private string _baseUrl = "";
+
+    public async Task InitializeAsync()
+    {
+        var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.LinkBlog_AppHost>();
+        _app = await appHost.BuildAsync();
+        await _app.StartAsync();
+
+        var httpClient = _app.CreateHttpClient("webfrontend");
+        _baseUrl = httpClient.BaseAddress!.ToString().TrimEnd('/');
+
+        _playwright = await Microsoft.Playwright.Playwright.CreateAsync();
+        _browser = await _playwright.Chromium.LaunchAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_browser is not null) await _browser.DisposeAsync();
+        _playwright?.Dispose();
+        if (_app is not null) await _app.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task HomePage_HasCorrectTitle()
+    {
+        var page = await _browser!.NewPageAsync();
+        await page.GotoAsync(_baseUrl);
+
+        await Assertions.Expect(page).ToHaveTitleAsync("David Jarman's Blog");
+    }
+
+    [Fact]
+    public async Task HomePage_ReturnsSuccessStatusCode()
+    {
+        var page = await _browser!.NewPageAsync();
+        var response = await page.GotoAsync(_baseUrl);
+
+        Assert.NotNull(response);
+        Assert.True(response.Ok, $"Expected OK response but got {response.Status}");
+    }
+
+    [Fact]
+    public async Task HomePage_ContainsNavigationLinks()
+    {
+        var page = await _browser!.NewPageAsync();
+        await page.GotoAsync(_baseUrl);
+
+        var nav = page.Locator("nav.page-links");
+        await Assertions.Expect(nav).ToBeVisibleAsync();
+        await Assertions.Expect(nav.GetByRole(AriaRole.Link, new() { Name = "Blogroll" })).ToBeVisibleAsync();
+        await Assertions.Expect(nav.GetByRole(AriaRole.Link, new() { Name = "RSS" })).ToBeVisibleAsync();
+    }
+}

--- a/test/LinkBlog.Playwright.Tests/HomePageTests.cs
+++ b/test/LinkBlog.Playwright.Tests/HomePageTests.cs
@@ -32,29 +32,15 @@ public class HomePageTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task HomePage_HasCorrectTitle()
-    {
-        var page = await _browser!.NewPageAsync();
-        await page.GotoAsync(_baseUrl);
-
-        await Assertions.Expect(page).ToHaveTitleAsync("David Jarman's Blog");
-    }
-
-    [Fact]
-    public async Task HomePage_ReturnsSuccessStatusCode()
+    public async Task HomePage_LoadsCorrectly()
     {
         var page = await _browser!.NewPageAsync();
         var response = await page.GotoAsync(_baseUrl);
 
         Assert.NotNull(response);
         Assert.True(response.Ok, $"Expected OK response but got {response.Status}");
-    }
 
-    [Fact]
-    public async Task HomePage_ContainsNavigationLinks()
-    {
-        var page = await _browser!.NewPageAsync();
-        await page.GotoAsync(_baseUrl);
+        await Assertions.Expect(page).ToHaveTitleAsync("David Jarman's Blog");
 
         var nav = page.Locator("nav.page-links");
         await Assertions.Expect(nav).ToBeVisibleAsync();

--- a/test/LinkBlog.Playwright.Tests/HomePageTests.cs
+++ b/test/LinkBlog.Playwright.Tests/HomePageTests.cs
@@ -40,7 +40,11 @@ public class HomePageTests : IAsyncLifetime
     [Fact]
     public async Task HomePage_LoadsCorrectly()
     {
-        var page = await _browser!.NewPageAsync();
+        BrowserNewPageOptions options = new()
+        {
+            IgnoreHTTPSErrors = true
+        };
+        var page = await _browser!.NewPageAsync(options);
         var response = await page.GotoAsync(_baseUrl);
 
         Assert.NotNull(response);

--- a/test/LinkBlog.Playwright.Tests/HomePageTests.cs
+++ b/test/LinkBlog.Playwright.Tests/HomePageTests.cs
@@ -1,4 +1,5 @@
 using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Testing;
 using Microsoft.Playwright;
 
@@ -13,12 +14,17 @@ public class HomePageTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        // Bypass GitHub OAuth for admin pages in test environment
+        Environment.SetEnvironmentVariable("DisableAdminAuth", "true");
+
         var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.LinkBlog_AppHost>();
         _app = await appHost.BuildAsync();
         await _app.StartAsync();
 
-        var httpClient = _app.CreateHttpClient("webfrontend");
-        _baseUrl = httpClient.BaseAddress!.ToString().TrimEnd('/');
+        var webResource = appHost.Resources.First(r=>r.Name == "webfrontend");
+        var endpoint = webResource.Annotations.OfType<EndpointAnnotation>().First(x => x.Name == "http");
+
+        _baseUrl = endpoint.AllocatedEndpoint!.UriString;
 
         _playwright = await Microsoft.Playwright.Playwright.CreateAsync();
         _browser = await _playwright.Chromium.LaunchAsync();

--- a/test/LinkBlog.Playwright.Tests/HomePageTests.cs
+++ b/test/LinkBlog.Playwright.Tests/HomePageTests.cs
@@ -21,7 +21,7 @@ public class HomePageTests : IAsyncLifetime
         _app = await appHost.BuildAsync();
         await _app.StartAsync();
 
-        var webResource = appHost.Resources.First(r=>r.Name == "webfrontend");
+        var webResource = appHost.Resources.First(r => r.Name == "webfrontend");
         var endpoint = webResource.Annotations.OfType<EndpointAnnotation>().First(x => x.Name == "http");
 
         _baseUrl = endpoint.AllocatedEndpoint!.UriString;

--- a/test/LinkBlog.Playwright.Tests/LinkBlog.Playwright.Tests.csproj
+++ b/test/LinkBlog.Playwright.Tests/LinkBlog.Playwright.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.Testing" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Playwright" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\LinkBlog.AppHost\LinkBlog.AppHost.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/LinkBlog.Web.Tests/FormValidationTests.cs
+++ b/test/LinkBlog.Web.Tests/FormValidationTests.cs
@@ -2,6 +2,7 @@ using Bunit;
 using LinkBlog.Abstractions;
 using LinkBlog.Data;
 using LinkBlog.Web.Components.Pages.Admin;
+using Microsoft.AspNetCore.OutputCaching;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -12,14 +13,17 @@ public class FormValidationTests : BunitContext
 {
     private readonly Mock<IPostStore> _mockPostStore;
     private readonly Mock<ILogger<AdminHome>> _mockLogger;
+    private readonly Mock<IOutputCacheStore> _mockOutputCacheStore;
 
     public FormValidationTests()
     {
         _mockPostStore = new Mock<IPostStore>();
         _mockLogger = new Mock<ILogger<AdminHome>>();
+        _mockOutputCacheStore = new Mock<IOutputCacheStore>();
 
         Services.AddSingleton(_mockPostStore.Object);
         Services.AddSingleton(_mockLogger.Object);
+        Services.AddSingleton(_mockOutputCacheStore.Object);
 
         // Setup authorization (since the component has [Authorize] attribute)
         Services.AddAuthorization(options =>


### PR DESCRIPTION
## Summary
- Add Playwright E2E test project with tests for the home page
- Add E2E tests for creating posts via the admin page
- Combine home page assertions into a single test for clarity

## Test plan
- [ ] Verify CI passes with the new Playwright test project
- [ ] Confirm home page tests assert correct content and structure
- [ ] Confirm admin post creation test covers the full create flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)