### PR TITLE
chore: Update NuGet packages to latest

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,27 +5,26 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Aspire -->
-    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="13.2.2" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.2.2" />
-    <PackageVersion Include="Magick.NET-Q8-AnyCPU" Version="14.11.1" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
+    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="13.2.4" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.2.4" />
+    <PackageVersion Include="Magick.NET-Q8-AnyCPU" Version="14.13.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
-    <PackageVersion Include="Markdig" Version="1.1.2" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="Markdig" Version="1.1.3" />
     <PackageVersion Include="YamlDotNet" Version="17.0.1" />
-
     <!-- Test packages -->
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.2.2" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.2.4" />
     <PackageVersion Include="bunit" Version="2.7.2" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.59.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
## Summary

- Updated all outdated NuGet packages in `Directory.Packages.props` to their latest versions
- All 14 unit tests pass; Playwright tests require Docker (unavailable in this environment, pre-existing infrastructure limitation)

## Packages Updated

| Package | From | To |
|---|---|---|
| `Aspire.Azure.Storage.Blobs` | 13.2.2 | 13.2.4 |
| `Aspire.Hosting.Azure.Storage` | 13.2.2 | 13.2.4 |
| `Aspire.Hosting.Testing` | 13.2.2 | 13.2.4 |
| `Magick.NET-Q8-AnyCPU` | 14.11.1 | 14.13.0 |
| `Markdig` | 1.1.2 | 1.1.3 |
| `Microsoft.Extensions.Caching.Memory` | 10.0.5 | 10.0.7 |
| `Microsoft.Extensions.Hosting.Abstractions` | 10.0.5 | 10.0.7 |
| `Microsoft.Extensions.Http.Resilience` | 10.4.0 | 10.5.0 |
| `Microsoft.Extensions.Options` | 10.0.5 | 10.0.7 |
| `Microsoft.Extensions.ServiceDiscovery` | 10.4.0 | 10.5.0 |
| `OpenTelemetry.Exporter.OpenTelemetryProtocol` | 1.15.2 | 1.15.3 |
| `OpenTelemetry.Extensions.Hosting` | 1.15.2 | 1.15.3 |
| `OpenTelemetry.Instrumentation.AspNetCore` | 1.15.1 | 1.15.2 |
| `OpenTelemetry.Instrumentation.Http` | 1.15.0 | 1.15.1 |
| `OpenTelemetry.Instrumentation.Runtime` | 1.15.0 | 1.15.1 |
| `coverlet.collector` | 8.0.1 | 10.0.0 |

## Test plan

- [x] `dotnet build` succeeds with no warnings or errors
- [x] `dotnet test` — all 14 unit tests in `LinkBlog.Web.Tests` pass
- [ ] Playwright integration tests require Docker (not available in this environment)

https://claude.ai/code/session_01JXS2zNkmBNrm48NjcWRtQn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXS2zNkmBNrm48NjcWRtQn)_